### PR TITLE
Fix a compilation error

### DIFF
--- a/Source/General/PlaceWorkers/PlaceWorker_NeverUnstandable.cs
+++ b/Source/General/PlaceWorkers/PlaceWorker_NeverUnstandable.cs
@@ -5,7 +5,7 @@ namespace FrontierDevelopments.General.PlaceWorkers
 {
     public class PlaceWorker_NeverUnstandable : PlaceWorker
     {
-        public override AcceptanceReport AllowsPlacing(BuildableDef def, IntVec3 center, Rot4 rot, Map map, Thing thingToIgnore = null, Thing thing)
+        public override AcceptanceReport AllowsPlacing(BuildableDef def, IntVec3 center, Rot4 rot, Map map, Thing thingToIgnore = null, Thing thing = null)
         {
             return !GenAdj.OccupiedRect(center, rot, def.Size).Cells.Any(cell => 
                 map.thingGrid.ThingsAt(cell)


### PR DESCRIPTION
Fix a compilation error, wherein a parameter without a default is declared after parameters with a default value.

Because this is an overridden method, just update the method declaration to match the parent's declaration.